### PR TITLE
Fix issue sergiohinojosa/Dynatrace-REST-Tenant-Automation#1 (Hard-coded IPv4 address causing issues with reverse proxy)

### DIFF
--- a/aws/ubuntu-setup-easytravel.sh
+++ b/aws/ubuntu-setup-easytravel.sh
@@ -195,22 +195,23 @@ installBankjobs() {
 installReverseProxy() {
   printInfoSection "Configuring reverse proxy"
   mkdir /home/$USER/nginx
+  IP_ADDR=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
   #
   echo 'upstream angular {
-    server   172.17.0.1:9080;
+    server   $IP_ADDR:9080;
 }
 
 upstream admin {
-    server   172.17.0.1:8094;
+    server   $IP_ADDR:8094;
 }
 upstream classic {
-    server   172.17.0.1:8079;
+    server   $IP_ADDR:8079;
 }
 upstream rest {
-    server   172.17.0.1:8091;
+    server   $IP_ADDR:8091;
 }
 upstream 3rdparty {
-    server   172.17.0.1:8092;
+    server   $IP_ADDR:8092;
 }
 
 server {

--- a/aws/ubuntu-setup-easytravel.sh
+++ b/aws/ubuntu-setup-easytravel.sh
@@ -198,20 +198,20 @@ installReverseProxy() {
   IP_ADDR=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
   #
   echo 'upstream angular {
-    server   $IP_ADDR:9080;
+    server   '$IP_ADDR':9080;
 }
 
 upstream admin {
-    server   $IP_ADDR:8094;
+    server   '$IP_ADDR':8094;
 }
 upstream classic {
-    server   $IP_ADDR:8079;
+    server   '$IP_ADDR':8079;
 }
 upstream rest {
-    server   $IP_ADDR:8091;
+    server   '$IP_ADDR':8091;
 }
 upstream 3rdparty {
-    server   $IP_ADDR:8092;
+    server   '$IP_ADDR':8092;
 }
 
 server {


### PR DESCRIPTION
Detect IP dynamically instead of using hard-coded one.